### PR TITLE
Fix duplicate sync game state call

### DIFF
--- a/stores/gameStore/realtime.ts
+++ b/stores/gameStore/realtime.ts
@@ -612,9 +612,6 @@ export const createRealtimeFunctions = (
               // Update the game state in the database
               get().syncGameStateToDatabase();
 
-              // Update the game state in the database
-              get().syncGameStateToDatabase();
-
               // Process trick completion logic
               if (updatedTrick.length === 4) {
                 console.log("[GameStore] Trick complete, resolving winner");


### PR DESCRIPTION
## Summary
- remove duplicate `syncGameStateToDatabase` comment and call in realtime game store

## Testing
- `pnpm run lint` *(fails: ESLint not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68507780c34c8331a465451503c482e6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Eliminated a duplicate database synchronization when playing a card, ensuring the game state is updated only once per action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->