### PR TITLE
Fix React use call

### DIFF
--- a/app/game/[roomId]/page.tsx
+++ b/app/game/[roomId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, Suspense, useMemo } from "react";
+import React, { useState, useEffect, Suspense, useMemo, use } from "react";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { detectBotsByName } from "./bot-voting-helper";
 import { GameBoard } from "@/components/game-board";
@@ -798,7 +798,7 @@ function GameRoomInitializer({
 }
 
 export default function GameRoomPage({ params }: GameRoomPageProps) {
-  const resolvedParams = React.use(params);
+  const resolvedParams = use(params);
   const roomId = resolvedParams.roomId;
 
   return (


### PR DESCRIPTION
## Summary
- import the new `use` hook from react
- call `use(params)` in the GameRoomPage

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6850777b3338833194163e919357fa6b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability in loading game room pages by updating how page parameters are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->