### PR TITLE
Fix repository name in clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ A modern card game built with Next.js, featuring real-time multiplayer gameplay 
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/SkwdStudios/turup-s-gambit.git
-cd turup-s-gambit
+git clone https://github.com/SkwdStudios/turup-s-gambits.git
+cd turup-s-gambits
 ```
 
 2. Install dependencies:


### PR DESCRIPTION
## Summary
- update README clone URL and cd command to use `turup-s-gambits`

## Testing
- `pnpm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850776d9eec83318fda82b9c67933bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the repository name in the installation instructions to ensure accurate cloning and navigation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->