### PR TITLE
Remove Google OAuth option

### DIFF
--- a/components/login-modal.tsx
+++ b/components/login-modal.tsx
@@ -311,33 +311,6 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
                 type="button"
                 variant="outline"
                 className="medieval-button"
-                onClick={() => handleOAuthLogin("google")}
-                disabled={isLoading}
-              >
-                <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-                  <path
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                    fill="#4285F4"
-                  />
-                  <path
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    fill="#34A853"
-                  />
-                  <path
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    fill="#FBBC05"
-                  />
-                  <path
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    fill="#EA4335"
-                  />
-                </svg>
-                Google
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                className="medieval-button"
                 onClick={() => handleOAuthLogin("discord")}
                 disabled={isLoading}
               >
@@ -381,42 +354,6 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
                 Sign up with Discord
               </Button>
 
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full medieval-button flex items-center gap-2"
-                onClick={() => handleOAuthLogin("google")}
-                disabled={isLoading}
-              >
-                {isLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <svg
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                    />
-                    <path
-                      fill="currentColor"
-                      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    />
-                    <path
-                      fill="currentColor"
-                      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    />
-                    <path
-                      fill="currentColor"
-                      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    />
-                  </svg>
-                )}
-                Sign up with Google
-              </Button>
             </div>
 
             <div className="relative mb-4">

--- a/lib/supabase-auth.ts
+++ b/lib/supabase-auth.ts
@@ -4,7 +4,7 @@ import { supabase } from "./supabase";
 // Use the same Supabase instance for authentication
 export const supabaseAuth = supabase;
 
-export type OAuthProvider = "discord" | "google";
+export type OAuthProvider = "discord";
 
 export const signInWithOAuth = async (provider: OAuthProvider) => {
   console.log(`[Auth] Starting OAuth sign in with ${provider}`);

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -27,7 +27,6 @@ function supabaseUserToUser(supabaseUser: any): User {
   // Handle different provider data structures
   const provider = supabaseUser.app_metadata?.provider;
   const isDiscord = provider === "discord";
-  const isGoogle = provider === "google";
   const isAnonymous = !provider && !supabaseUser.email;
 
   // Get the best username based on provider
@@ -58,15 +57,6 @@ function supabaseUserToUser(supabaseUser: any): User {
     } else {
       avatar = userData.avatar_url || userData.picture;
     }
-  } else if (isGoogle) {
-    // Google-specific data extraction
-    username =
-      userData.name ||
-      userData.full_name ||
-      userData.email?.split("@")[0] ||
-      "User";
-    name = userData.name || userData.full_name || username;
-    avatar = userData.picture || userData.avatar_url;
   } else if (isAnonymous) {
     // Special handling for anonymous users - prioritize username from metadata
     // This prevents the temporary "User" display before updating to the real username


### PR DESCRIPTION
## Summary
- keep only Discord OAuth for login/signup
- drop Google OAuth type and code

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f02ab84c83319c932b7040aaaba5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Removed Google as an OAuth login and signup option. Only Discord OAuth is now available.

- **Refactor**
  - Simplified user data handling by removing Google-specific logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->